### PR TITLE
Update cash.py

### DIFF
--- a/pset6/sentimental/cash/cash.py
+++ b/pset6/sentimental/cash/cash.py
@@ -7,7 +7,7 @@ def main():
         dollars_owed = get_float("Change owed: ")
         cents_owed = floor(dollars_owed * 100)
 
-        if cents_owed > 0:
+        if cents_owed <= 0:
             break
 
     quarters = cents_owed // 25


### PR DESCRIPTION
if cents_owed must be greater than zero. In the original file, it was:
if cents_owed > 0:
    break
It means it always breaks when entering a valid number.